### PR TITLE
minimum version of python to 3.7

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = ["Lorenzo C. <lorenzo@deepcellbio.com>"]
 
 [tool.poetry.dependencies]
-python = "~3.10"
+python = "~3.7"
 fastapi = "^0.78.*"
 SQLAlchemy = "^1.4.36"
 passlib = { extras = ["bcrypt"], version = "^1.7.4" }


### PR DESCRIPTION
Before, the minimum version of Python was `3.10` which IMHO won't be the case for most developers(at least for development). I have downed the version to `3.7`.

Any suggestions are welcomed. :smile: 